### PR TITLE
Add support for input/output-only devices and full-speed USB feedback packets

### DIFF
--- a/src/uac2-asio/USBAsio.cpp
+++ b/src/uac2-asio/USBAsio.cpp
@@ -582,7 +582,7 @@ ASIOError CUSBAsio::getSampleRate(ASIOSampleRate * sampleRate)
         *sampleRate = m_sampleRate;
     }
     // info_print_("getSampleRate\n");
-    // info_print_("current %lf Hz, device current %u Hz\n",this->m_sampleRate,m_audioProperty.sampleRate);
+    // info_print_("current %lf Hz, device current %u Hz\n",this->m_sampleRate,m_audioProperty.SampleRate);
     return ASE_OK;
 }
 

--- a/src/uac2-asio/USBDevice.cpp
+++ b/src/uac2-asio/USBDevice.cpp
@@ -109,7 +109,7 @@ static HANDLE OpenUsbDeviceCore(
                             {
                                 UAC_AUDIO_PROPERTY audioProp;
                                 result = GetAudioProperty(targetHandle, &audioProp);
-                                if (result && (audioProp.OutputAsioChannels != 0))
+                                if (result && !((audioProp.OutputAsioChannels == 0) && (audioProp.InputAsioChannels == 0)))
                                 {
                                     info_print_("successfully opened %s\n", deviceInterfaceDetailData->DevicePath);
                                     delete[] (BYTE *)deviceInterfaceDetailData;

--- a/src/uac2-driver/AsioBufferObject.h
+++ b/src/uac2-driver/AsioBufferObject.h
@@ -102,12 +102,14 @@ class AsioBufferObject
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     bool EvaluatePositionAndNotifyIfNeeded(
-        _In_ ULONGLONG currentTimePCUs,
-        _In_ ULONGLONG lastAsioNotifyPCUs,
-        _In_ ULONGLONG asioNotifyCount,
-        _In_ LONG      prevAsioMeasuredPeriodUs,
-        _In_ LONG      curClientProcessingTimeUs,
-        _Out_ LONG &   curAsioMeasuredPeriodUs
+        _In_ ULONGLONG  currentTimePCUs,
+        _In_ ULONGLONG  lastAsioNotifyPCUs,
+        _In_ ULONGLONG  asioNotifyCount,
+        _In_ LONG       prevAsioMeasuredPeriodUs,
+        _In_ LONG       curClientProcessingTimeUs,
+        _Out_ LONG &    curAsioMeasuredPeriodUs,
+        _In_ const bool hasInputIsochronousInterface,
+        _In_ const bool hasOutputIsochronousInterface
     );
 
     __drv_maxIRQL(DISPATCH_LEVEL)

--- a/src/uac2-driver/CaptureCircuit.cpp
+++ b/src/uac2-driver/CaptureCircuit.cpp
@@ -428,9 +428,10 @@ Return Value:
     RETURN_NTSTATUS_IF_FAILED(deviceContext->UsbAudioConfiguration->GetStreamDevices(true, numOfDevices));
     numOfRemainingChannels = numOfChannels;
 
-	if (numOfChannels == 0) {
-		return STATUS_SUCCESS;
-	}
+    if (numOfChannels == 0)
+    {
+        return STATUS_SUCCESS;
+    }
 
     USBAudioDataFormatManager * usbAudioDataFormatManager = deviceContext->UsbAudioConfiguration->GetUSBAudioDataFormatManager(true);
     RETURN_NTSTATUS_IF_TRUE_ACTION(usbAudioDataFormatManager == nullptr, status = STATUS_INVALID_PARAMETER, status);

--- a/src/uac2-driver/CaptureCircuit.cpp
+++ b/src/uac2-driver/CaptureCircuit.cpp
@@ -394,7 +394,7 @@ Return Value:
     UCHAR                           muteUnitID = USBAudioConfiguration::InvalidID;
     ULONG                           numOfDevices = 0;
     ULONG                           numOfConnections = 0;
-    ULONG                           numOfRemainingChannels;
+    ULONG                           numOfRemainingChannels = 0;
 
     PAGED_CODE();
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Entry");
@@ -427,6 +427,10 @@ Return Value:
     RETURN_NTSTATUS_IF_FAILED(deviceContext->UsbAudioConfiguration->GetStreamChannelInfo(true, numOfChannels, terminalType, volumeUnitID, muteUnitID));
     RETURN_NTSTATUS_IF_FAILED(deviceContext->UsbAudioConfiguration->GetStreamDevices(true, numOfDevices));
     numOfRemainingChannels = numOfChannels;
+
+	if (numOfChannels == 0) {
+		return STATUS_SUCCESS;
+	}
 
     USBAudioDataFormatManager * usbAudioDataFormatManager = deviceContext->UsbAudioConfiguration->GetUSBAudioDataFormatManager(true);
     RETURN_NTSTATUS_IF_TRUE_ACTION(usbAudioDataFormatManager == nullptr, status = STATUS_INVALID_PARAMETER, status);

--- a/src/uac2-driver/CircuitHelper.cpp
+++ b/src/uac2-driver/CircuitHelper.cpp
@@ -42,7 +42,7 @@ const ULONG _DSP_STREAM_PROPERTY_UI4_VALUE = 1;
 const ULONG c_SampleRateList[] = {
     11025, 22050, 32000, 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000, 705600, 768000
 };
-const ULONG c_SampleRateCount = sizeof(c_SampleRateList) / sizeof(c_SampleRateList[0]);
+const ULONG c_SampleRateCount = SIZEOF_ARRAY(c_SampleRateList);
 
 PAGED_CODE_SEG
 NTSTATUS AllocateFormat(

--- a/src/uac2-driver/ContiguousMemory.cpp
+++ b/src/uac2-driver/ContiguousMemory.cpp
@@ -112,6 +112,14 @@ ContiguousMemory::Allocate(
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - this, m_contiguousMemory, %p, %p", this, m_contiguousMemory);
     for (ULONG direction = 0; direction < toULONG(IsoDirection::NumOfIsoDirection); ++direction)
     {
+        if ((static_cast<IsoDirection>(direction) == IsoDirection::In) && !usbAudioConfiguration->hasInputIsochronousInterface())
+        {
+            continue;
+        }
+        if ((static_cast<IsoDirection>(direction) == IsoDirection::Out) && !usbAudioConfiguration->hasOutputIsochronousInterface())
+        {
+            continue;
+        }
         ULONG maxPacketSize = GetMaxPacketSize(usbAudioConfiguration, static_cast<IsoDirection>(direction));
         if (maxPacketSize == 0)
         {
@@ -121,7 +129,7 @@ ContiguousMemory::Allocate(
 
         // >>comment-001<<
         m_contiguousMemorySize[direction] = maxPacketSize * maxBurstOverride * maxClassicFramesPerIrp * framesPerMs;
-        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Max Contiguous Memory Size = = %d", m_contiguousMemorySize[direction]);
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Max Contiguous Memory Size = %d", m_contiguousMemorySize[direction]);
 
         for (ULONG index = 0; index < UAC_MAX_IRP_NUMBER; ++index)
         {

--- a/src/uac2-driver/StreamObject.cpp
+++ b/src/uac2-driver/StreamObject.cpp
@@ -736,7 +736,7 @@ StreamStatuses StreamObject::GetStreamStatuses(bool & isProcessIo)
     WdfSpinLockAcquire(m_positionSpinLock);
 
     status = static_cast<StreamStatuses>(m_streamStatus);
-    if (m_deviceContext->UsbAudioConfiguration->hasInputIsochronousInterface())
+    if (m_deviceContext->UsbAudioConfiguration->hasInputAndOutputIsochronousInterfaces())
     {
         isProcessIo = m_inputLastProcessedIrpIndex == m_outputLastProcessedIrpIndex;
     }
@@ -1033,7 +1033,7 @@ bool StreamObject::CreateCompletedInputPacketList(
         {
             inputBuffers[i] = *inputRemainder;
             inProcessRemainder = true;
-            // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - in process remainder true, transfer object %p", inputBuffers[i].transferObject);
+            // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - in process remainder true, transfer object %p", inputBuffers[i].TransferObject);
         }
         else
         {

--- a/src/uac2-driver/StreamObject.cpp
+++ b/src/uac2-driver/StreamObject.cpp
@@ -28,6 +28,7 @@ Environment:
 #include "Public.h"
 #include "Common.h"
 #include "USBAudio.h"
+#include "USBAudioConfiguration.h"
 #include "StreamObject.h"
 #include "ErrorStatistics.h"
 #include "TransferObject.h"
@@ -41,20 +42,26 @@ Environment:
 _Use_decl_annotations_
 PAGED_CODE_SEG
 StreamObject * StreamObject::Create(
-    PDEVICE_CONTEXT deviceContext
+    PDEVICE_CONTEXT      deviceContext,
+    const StreamStatuses ioStable,
+    const StreamStatuses ioStreaming,
+    const StreamStatuses ioSteady
 )
 {
     PAGED_CODE();
 
-    return new (POOL_FLAG_NON_PAGED, DRIVER_TAG) StreamObject(deviceContext);
+    return new (POOL_FLAG_NON_PAGED, DRIVER_TAG) StreamObject(deviceContext, ioStable, ioStreaming, ioSteady);
 }
 
 _Use_decl_annotations_
 PAGED_CODE_SEG
 StreamObject::StreamObject(
-    PDEVICE_CONTEXT deviceContext
+    PDEVICE_CONTEXT      deviceContext,
+    const StreamStatuses ioStable,
+    const StreamStatuses ioStreaming,
+    const StreamStatuses ioSteady
 )
-    : m_deviceContext(deviceContext)
+    : m_deviceContext(deviceContext), c_ioStable(ioStable), c_ioStreaming(ioStreaming), c_ioSteady(ioSteady)
 {
     WDF_OBJECT_ATTRIBUTES attributes;
 
@@ -380,9 +387,7 @@ void StreamObject::CompleteRequest(
     ULONGLONG                     timeDiffUs = (LONGLONG)currentTimeUs - lastTimeUs;
     ULONG                         thresholdUs = CalculateDropoutThresholdTime();
 
-    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - currentTimeUs, qpcPosition), %s, %llu, %llu,", direction == IsoDirection::In ? "In" : direction == IsoDirection::Out ? "Out"
-                                                                                                                                                                            : "feedback",
-                currentTimeUs, qpcPosition);
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - currentTimeUs, qpcPosition, %s, %llu, %llu,", GetDirectionString(direction), currentTimeUs, qpcPosition);
 
     if ((lastTimeUs != 0) && (timeDiffUs > thresholdUs))
     {
@@ -390,9 +395,7 @@ void StreamObject::CompleteRequest(
         {
             m_deviceContext->AsioBufferObject->SetRecDeviceStatus(DeviceStatuses::OverloadDetected);
         }
-        TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE, "process transfer %s: dropout detected. Elapsed time after previous DPC: %llu us, threshold %uus.", (direction == IsoDirection::In) ? "input" : (direction == IsoDirection::Out) ? "output"
-                                                                                                                                                                                                                                      : "feedback",
-                    timeDiffUs, thresholdUs);
+        TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE, "process transfer %s: dropout detected. Elapsed time after previous DPC: %llu us, threshold %uus.", GetDirectionString(direction), timeDiffUs, thresholdUs);
         m_deviceContext->ErrorStatistics->LogErrorOccurrence(ErrorStatus::DropoutDetectedElapsedTime, (ULONG)(timeDiffUs - thresholdUs));
     }
 #ifdef BUFFER_THREAD_STATISTICS
@@ -505,14 +508,14 @@ StreamObject::CalculateTransferSizeAndSetURB(
 
     m_inputPrevWritePosition = inPosition;
 
-    if ((m_deviceContext->IsDeviceSynchronous) || ((m_streamStatus & toInt(StreamStatuses::IoStable)) != (ULONG)toInt(StreamStatuses::IoStable) && !m_feedbackStable) || (lockDelayCount != 0) || (requiredSamples < numPackets))
+    if ((m_deviceContext->IsDeviceSynchronous) || ((m_streamStatus & toInt(c_ioStable)) != (ULONG)toInt(c_ioStable) && !m_feedbackStable) || (lockDelayCount != 0) || (requiredSamples < numPackets))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "preparing output packets by calculation (independent to input)...");
         transferSamples = 0;
 
         LONG  remainder = m_deviceContext->AudioProperty.SampleRate % m_deviceContext->AudioProperty.PacketsPerSec;
         ULONG rounded = m_deviceContext->AudioProperty.SamplesPerPacket * m_deviceContext->AudioProperty.PacketsPerSec;
-        if ((m_streamStatus & toInt(StreamStatuses::IoStable)) == (ULONG)toInt(StreamStatuses::IoStable) && m_deviceContext->AudioProperty.InputMeasuredSampleRate != 0)
+        if ((m_streamStatus & toInt(c_ioStable)) == (ULONG)toInt(c_ioStable) && m_deviceContext->AudioProperty.InputMeasuredSampleRate != 0)
         {
             remainder = ((LONG)m_deviceContext->AudioProperty.InputMeasuredSampleRate - (LONG)rounded) % (LONG)m_deviceContext->AudioProperty.PacketsPerSec;
         }
@@ -558,12 +561,12 @@ StreamObject::CalculateTransferSizeAndSetURB(
             transferSize += packetSize;
             InterlockedIncrement(asyncPacketsCount);
         }
-        if (m_deviceContext->IsDeviceSynchronous && (m_streamStatus & toInt(StreamStatuses::IoStable)) == (ULONG)toInt(StreamStatuses::IoStable))
+        if (m_deviceContext->IsDeviceSynchronous && (m_streamStatus & toInt(c_ioStable)) == (ULONG)toInt(c_ioStable))
         {
             transferSamples = transferSize / m_deviceContext->AudioProperty.OutputBytesPerBlock;
             m_outputSyncPosition += transferSize;
         }
-        if (!m_deviceContext->IsDeviceSynchronous && ((m_streamStatus & toInt(StreamStatuses::IoStable)) == (ULONG)toInt(StreamStatuses::IoStable) || m_feedbackStable))
+        if (!m_deviceContext->IsDeviceSynchronous && ((m_streamStatus & toInt(c_ioStable)) == (ULONG)toInt(c_ioStable) || m_feedbackStable))
         {
             // In cases where the OUT DPC comes back before the IN DPC,
             // the number of samples is calculated based on the theoretical value and sent.
@@ -573,14 +576,13 @@ StreamObject::CalculateTransferSizeAndSetURB(
             {
                 m_transferObjectFeedback[index]->SetPresendSamples(transferSamples);
             }
-            else if ((m_streamStatus & toInt(StreamStatuses::IoStable)) == (ULONG)toInt(StreamStatuses::IoStable) && (lockDelayCount == 0) && (m_inputTransferObject[index] != nullptr))
+            else if ((m_streamStatus & toInt(c_ioStable)) == (ULONG)toInt(c_ioStable) && (lockDelayCount == 0) && (m_inputTransferObject[index] != nullptr))
             {
                 m_inputTransferObject[index]->SetPresendSamples(transferSamples);
             }
 
             m_outputSyncPosition += transferSize;
         }
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "initialized OUT URB. in sample %I64d, out sample %I64d, startFrame %d, %u bytes", inPosition / m_deviceContext->AudioProperty.InputBytesPerBlock, readPosition / m_deviceContext->AudioProperty.OutputBytesPerBlock, startFrame, transferSize);
     }
     else
     {
@@ -637,7 +639,14 @@ StreamObject::CalculateTransferSizeAndSetURB(
             }
         }
         m_outputSyncPosition += transferSize;
+    }
+    if (m_deviceContext->UsbAudioConfiguration->hasInputIsochronousInterface())
+    {
         TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "initialized OUT URB. in sample %I64d, out sample %I64d, startFrame %d, %u bytes", inPosition / m_deviceContext->AudioProperty.InputBytesPerBlock, readPosition / m_deviceContext->AudioProperty.OutputBytesPerBlock, startFrame, transferSize);
+    }
+    else
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "initialized OUT URB. out sample %I64d, startFrame %d, %u bytes", readPosition / m_deviceContext->AudioProperty.OutputBytesPerBlock, startFrame, transferSize);
     }
     m_outputReadPosition += transferSize;
 
@@ -727,7 +736,14 @@ StreamStatuses StreamObject::GetStreamStatuses(bool & isProcessIo)
     WdfSpinLockAcquire(m_positionSpinLock);
 
     status = static_cast<StreamStatuses>(m_streamStatus);
-    isProcessIo = m_inputLastProcessedIrpIndex == m_outputLastProcessedIrpIndex;
+    if (m_deviceContext->UsbAudioConfiguration->hasInputIsochronousInterface())
+    {
+        isProcessIo = m_inputLastProcessedIrpIndex == m_outputLastProcessedIrpIndex;
+    }
+    else
+    {
+        isProcessIo = true;
+    }
 
     WdfSpinLockRelease(m_positionSpinLock);
 
@@ -929,6 +945,10 @@ void StreamObject::UpdateCompletedPacket(
     {
         currentPacketNumber = (ULONG)((m_outputCompletedPacket / numberOfPackets) % m_deviceContext->Params.MaxIrpNumber);
         m_outputCompletedPacket += numberOfPackets;
+        if (!m_deviceContext->UsbAudioConfiguration->hasInputIsochronousInterface())
+        {
+            m_inputCompletedPacket = m_outputCompletedPacket;
+        }
     }
     WdfSpinLockRelease(m_packetSpinLock);
 
@@ -1074,7 +1094,7 @@ bool StreamObject::CreateCompletedOutputPacketList(
             ULONG            irp = (ULONG)((m_outputProcessedPacket / packetsPerIrp) % numIrp);
             ULONG            packet = (ULONG)(m_outputProcessedPacket % packetsPerIrp);
             TransferObject * transferObject = m_outputTransferObject[irp];
-            // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - irp %u, transfer object %p", irp, transferObject);
+            // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - irp %u, transfer object %p, index %d", irp, transferObject, (transferObject != nullptr)? transferObject->GetIndex(): -1);
             if (transferObject != nullptr)
             {
                 outputBuffers[outputBuffersCount].Buffer = transferObject->GetRecordedIsoPacketBuffer(packet);
@@ -1111,15 +1131,26 @@ bool StreamObject::IsInputPacketAtEstimatedPosition(
 
 _Use_decl_annotations_
 PAGED_CODE_SEG
-bool StreamObject::IsOutputPacketAtEstimatedPosition(
+bool StreamObject::IsOutputPacketOverlapWithEstimatePosition(
     _In_ ULONG outLimit
 )
 {
     PAGED_CODE();
 
-    // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Out processed packet %llu, estimated packet %llu, out limit %u", m_outputProcessedPacket, m_inputEstimatedPacket, outLimit);
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Out processed packet %llu, estimated packet %llu, out limit %u", m_outputProcessedPacket, m_inputEstimatedPacket, outLimit);
+
     // Use Input m_inputEstimatedPacket
     return m_outputProcessedPacket >= (m_inputEstimatedPacket + outLimit);
+}
+
+_Use_decl_annotations_
+PAGED_CODE_SEG
+bool StreamObject::IsOutputPacketAtEstimatedPosition()
+{
+    PAGED_CODE();
+
+    // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Out processed packet %llu, estimated packet %llu, sync packet %llu, result %!bool!", m_outputProcessedPacket, m_inputEstimatedPacket, m_inputSyncPacket, m_outputProcessedPacket >= m_inputEstimatedPacket);
+    return m_outputProcessedPacket >= m_inputEstimatedPacket;
 }
 
 _Use_decl_annotations_
@@ -1216,8 +1247,18 @@ ULONG StreamObject::UpdatePositionsFeedback(
 
     if (validFeedback != 0)
     {
-        m_lastFeedbackSize = feedbackSum / 0x10000;
-        m_feedbackRemainder = feedbackSum % 0x10000;
+        if ((m_deviceContext->IsDeviceSuperSpeed && m_deviceContext->SuperSpeedCompatible) || (m_deviceContext->IsDeviceHighSpeed))
+        {
+            // For high-speed endpoints, the value is treated as a fixed-point number in 16.16 format.
+            m_lastFeedbackSize = feedbackSum / 0x10000;
+            m_feedbackRemainder = feedbackSum % 0x10000;
+        }
+        else
+        {
+            // For full-speed endpoints, the value is treated as a fixed-point number in 10.14 format.
+            m_lastFeedbackSize = feedbackSum / 0x4000;
+            m_feedbackRemainder = feedbackSum % 0x4000;
+        }
 
         if (m_inputValidPackets == 0)
         {
@@ -1286,7 +1327,7 @@ bool StreamObject::IsIoSteady()
 
     WdfSpinLockAcquire(m_positionSpinLock);
 
-    isIoSteady = (m_streamStatus == (ULONG)toInt(StreamStatuses::IoSteady));
+    isIoSteady = (m_streamStatus == (ULONG)toInt(c_ioSteady));
 
     WdfSpinLockRelease(m_positionSpinLock);
 
@@ -1352,31 +1393,31 @@ void StreamObject::ReportPacketLoopReason(
     switch (packetLoopReason)
     {
     case PacketLoopReason::ContinueLoop:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: CONTINUE_LOOP", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ContinueLoop", label);
         break;
     case PacketLoopReason::ExitLoopListCycleCompleted:
         TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopListCycleCompleted", label);
         break;
     case PacketLoopReason::ExitLoopAsioNotifyTimeExceeded:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_ASIO_NOTIFY_TIME_EXCEEDEDD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopAsioNotifyTimeExceeded", label);
         break;
     case PacketLoopReason::ExitLoopPacketEstimateReached:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_PACKET_ESTIMATE_REACHEDD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopPacketEstimateReached", label);
         break;
     case PacketLoopReason::ExitLoopNoMoreAsioBuffers:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_NO_MORE_ASIO_BUFFERSD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopNoMoreAsioBuffers", label);
         break;
     case PacketLoopReason::ExitLoopAtAsioBoundary:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_AT_ASIO_BOUNDARYD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopAtAsioBoundary", label);
         break;
     case PacketLoopReason::ExitLoopAfterSafetyOffset:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_AFTER_SAFETY_OFFSETD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopAfterSafetyOffset", label);
         break;
     case PacketLoopReason::ExitLoopAtInSync:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_AT_IN_SYNCD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopAtInSync", label);
         break;
     case PacketLoopReason::ExitLoopToPreventOutOverlap:
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: EXIT_LOOP_TO_PREVENT_OUT_OVERLAPD", label);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: ExitLoopToPreventOutOverlap", label);
         break;
     default:
         TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%s: packetLoopReason is illegal.", label);
@@ -1453,6 +1494,8 @@ void StreamObject::MixingEngineThreadMain(
     LONG          prevClientProcessingTimeUs = 0;
     LARGE_INTEGER timerExpired = {0};
     LONGLONG      asioNotifyCount = 0LL;
+    const bool    hasInputIsochronousInterface = m_deviceContext->UsbAudioConfiguration->hasInputIsochronousInterface();
+    const bool    hasOutputIsochronousInterface = m_deviceContext->UsbAudioConfiguration->hasOutputIsochronousInterface();
 
     PAGED_CODE();
 
@@ -1486,7 +1529,17 @@ void StreamObject::MixingEngineThreadMain(
 
         ULONG pcDiffUs = static_cast<ULONG>(GetWakeUpDiffPCUs());
 
-        LONG inElapsedTimeAfterDpc = (LONG)((LONGLONG)currentTimePCUs - m_inputIsoRequestCompletionTime.LastTimeUs);
+        LONG inElapsedTimeAfterDpc = 0;
+
+        if (hasInputIsochronousInterface)
+        {
+            inElapsedTimeAfterDpc = (LONG)((LONGLONG)currentTimePCUs - m_inputIsoRequestCompletionTime.LastTimeUs);
+        }
+        else
+        {
+            inElapsedTimeAfterDpc = (LONG)((LONGLONG)currentTimePCUs - m_outputIsoRequestCompletionTime.LastTimeUs);
+        }
+
         if ((m_deviceContext->AsioBufferObject != nullptr) && m_deviceContext->AsioBufferObject->IsRecBufferReady() && m_deviceContext->AsioBufferObject->IsRecHeaderRegistered() && (asioNotifyCount > 1))
         {
             ULONG thresholdUs = CalculateDropoutThresholdTime();
@@ -1513,8 +1566,8 @@ void StreamObject::MixingEngineThreadMain(
         LONGLONG inCompletedPacket = 0LL;  // IN Number of packets that have been transferred isochronous
         LONGLONG outCompletedPacket = 0LL; // OUT Number of packets that have been transferred isochronous
         GetCompletedPacket(inCompletedPacket, outCompletedPacket);
-
-        bool handleAsioBuffer = ((streamStatus == StreamStatuses::IoSteady) && (deviceContext->AsioBufferObject != nullptr) && deviceContext->AsioBufferObject->IsRecBufferReady() && (m_recoverActive == 0) && (m_outputRequireZeroFill == 0) && !IsFirstWakeUp());
+        // TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - in completed packet, out completed packet %llu, %lld", inCompletedPacket, outCompletedPacket);
+        bool handleAsioBuffer = ((streamStatus == c_ioSteady) && (deviceContext->AsioBufferObject != nullptr) && deviceContext->AsioBufferObject->IsRecBufferReady() && (m_recoverActive == 0) && (m_outputRequireZeroFill == 0) && !IsFirstWakeUp());
 
         LONGLONG playReadyPosition = {0};
         if (deviceContext->AsioBufferObject != nullptr && deviceContext->AsioBufferObject->IsRecBufferReady())
@@ -1572,7 +1625,7 @@ void StreamObject::MixingEngineThreadMain(
                     break;
                 }
 
-                if (handleAsioBuffer)
+                if (handleAsioBuffer && hasInputIsochronousInterface)
                 {
                     LONG asioRemainSamples = (LONG)((m_asioReadyPosition + deviceContext->AsioBufferObject->GetBufferPeriod()) - m_inputAsioBufferedPosition);
                     LONG asioRemainBytes = asioRemainSamples * deviceContext->AudioProperty.InputBytesPerBlock;
@@ -1654,18 +1707,30 @@ void StreamObject::MixingEngineThreadMain(
                     }
                 }
 
-                ULONG outLimit = (((deviceContext->Params.MaxIrpNumber - 1) * deviceContext->ClassicFramesPerIrp) * deviceContext->FramesPerMs);
-
-                if (IsOutputPacketAtEstimatedPosition(outLimit))
+                if (hasInputIsochronousInterface)
                 {
-                    // Prevents OUT processing from going around once the buffer and reaching the currently processed position
-                    outLoopExitReason = PacketLoopReason::ExitLoopToPreventOutOverlap;
-                    break;
+                    // input enable
+                    ULONG outLimit = (((deviceContext->Params.MaxIrpNumber - 1) * deviceContext->ClassicFramesPerIrp) * deviceContext->FramesPerMs);
+                    if (IsOutputPacketOverlapWithEstimatePosition(outLimit))
+                    {
+                        // Prevents OUT processing from going around once the buffer and reaching the currently processed position
+                        outLoopExitReason = PacketLoopReason::ExitLoopToPreventOutOverlap;
+                        break;
+                    }
                 }
-
+                else
+                {
+                    // input disable
+                    if (IsOutputPacketAtEstimatedPosition())
+                    {
+                        // Processing position reaches current position prediction
+                        outLoopExitReason = PacketLoopReason::ExitLoopPacketEstimateReached;
+                        break;
+                    }
+                }
                 outProcessRemainder = CreateCompletedOutputPacketList(m_outputBuffers, &outRemainder, outBuffersCount, packetsPerIrp, numIrp);
 
-                if (handleAsioBuffer)
+                if (handleAsioBuffer && hasOutputIsochronousInterface)
                 {
                     LONG asioRemain = (LONG)((playReadyPosition - m_outputAsioBufferedPosition) * deviceContext->AudioProperty.OutputBytesPerBlock);
                     {
@@ -1722,7 +1787,7 @@ void StreamObject::MixingEngineThreadMain(
                 // RecoverTransferError(StreamObject->DeviceObject, StreamObject);
                 break;
             }
-            if ((GetStreamStatuses() != StreamStatuses::IoStreaming) ||
+            if ((GetStreamStatuses() != c_ioStreaming) ||
                 (m_inputTransferObject[0]->GetLockDelayCount() != 0) ||
                 (m_outputTransferObject[0]->GetLockDelayCount() != 0))
             {
@@ -1744,7 +1809,8 @@ void StreamObject::MixingEngineThreadMain(
         ULONG dpcOffset = deviceContext->ClassicFramesPerIrp * deviceContext->FramesPerMs;
         LONG  safetyOffset = (LONG)(m_outputProcessedPacket - m_inputProcessedPacket) - (LONG)deviceContext->UsbLatency.InputOffsetFrame - (LONG)(dpcOffset);
         if (safetyOffset < (LONG)(outMinOffsetFrame) &&
-            deviceContext->AsioBufferObject != nullptr && deviceContext->AsioBufferObject->IsRecHeaderRegistered())
+            deviceContext->AsioBufferObject != nullptr && deviceContext->AsioBufferObject->IsRecHeaderRegistered() &&
+            (hasOutputIsochronousInterface && hasInputIsochronousInterface))
         {
             TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE, "dropout detected. Safety offset %d, minimum offset frame %d", safetyOffset, outMinOffsetFrame);
             deviceContext->AsioBufferObject->SetRecDeviceStatus(DeviceStatuses::OverloadDetected);
@@ -1752,9 +1818,9 @@ void StreamObject::MixingEngineThreadMain(
         }
 
         TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - In buffers count %u, ioStable 0x%x, inLoopExitReason %u", inBuffersCount, static_cast<ULONG>(streamStatus), static_cast<ULONG>(inLoopExitReason));
-        for (ULONG bufIndex = 0; bufIndex < inBuffersCount; ++bufIndex)
+        if ((streamStatus == c_ioSteady) && hasInputIsochronousInterface)
         {
-            if (streamStatus == StreamStatuses::IoSteady)
+            for (ULONG bufIndex = 0; bufIndex < inBuffersCount; ++bufIndex)
             {
                 // ULONG length = m_inputBuffers[bufIndex].length;
                 if (handleAsioBuffer)
@@ -1789,50 +1855,55 @@ void StreamObject::MixingEngineThreadMain(
                 }
             }
         }
-
         ULONG bytesPerBlock = deviceContext->AudioProperty.OutputBytesPerBlock;
 
         TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - Out buffers count %u, ioStable 0x%x, outLoopExitReason %u", outBuffersCount, static_cast<int>(streamStatus), static_cast<ULONG>(outLoopExitReason));
-        for (ULONG bufIndex = 0; bufIndex < outBuffersCount; ++bufIndex)
+
+        if (hasOutputIsochronousInterface)
         {
-            ULONG  transferSize = m_outputBuffers[bufIndex].Length;
-            PUCHAR outBufferStart = m_outputBuffers[bufIndex].Buffer + m_outputBuffers[bufIndex].Offset;
-            ULONG  outChannels = deviceContext->OutputUsbChannels;
-            ULONG  samples = transferSize / bytesPerBlock;
-
-            StreamObject::ClearOutputBuffer(deviceContext->AudioProperty.CurrentSampleFormat, outBufferStart, outChannels, bytesPerBlock, samples);
-            if (streamStatus == StreamStatuses::IoSteady)
+            for (ULONG bufIndex = 0; bufIndex < outBuffersCount; ++bufIndex)
             {
-                if (handleAsioBuffer)
-                {
-                    if (!NT_SUCCESS(deviceContext->AsioBufferObject->CopyFromAsioToOutputData(
-                            outBufferStart,
-                            transferSize,
-                            bytesPerBlock,
-                            deviceContext->AudioProperty.OutputBytesPerSample
-                        )))
-                    {
-                        StreamObject::ClearOutputBuffer(deviceContext->AudioProperty.CurrentSampleFormat, outBufferStart, outChannels, bytesPerBlock, samples);
-                    }
-                }
+                ULONG  transferSize = m_outputBuffers[bufIndex].Length;
+                PUCHAR outBufferStart = m_outputBuffers[bufIndex].Buffer + m_outputBuffers[bufIndex].Offset;
+                ULONG  outChannels = deviceContext->OutputUsbChannels;
+                ULONG  samples = transferSize / bytesPerBlock;
 
-                if (deviceContext->RtPacketObject != nullptr)
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - outputBuffers[%u] Irp, Packet, PacketID, TransferObject, Index, %u, %u, %u, %p, %u, %llu, %lld", bufIndex, m_outputBuffers[bufIndex].Irp, m_outputBuffers[bufIndex].Packet, m_outputBuffers[bufIndex].PacketId, m_outputBuffers[bufIndex].TransferObject, m_outputBuffers[bufIndex].TransferObject->GetIndex(), m_outputBuffers[bufIndex].TransferObject->GetQPCPosition(), (bufIndex == 0) ? 0LL : (LONGLONG)(m_outputBuffers[bufIndex].TransferObject->GetQPCPosition()) - (LONGLONG)(m_outputBuffers[bufIndex - 1].TransferObject->GetQPCPosition()));
+
+                StreamObject::ClearOutputBuffer(deviceContext->AudioProperty.CurrentSampleFormat, outBufferStart, outChannels, bytesPerBlock, samples);
+                if (streamStatus == c_ioSteady)
                 {
-                    for (ULONG deviceIndex = 0; deviceIndex < deviceContext->NumOfOutputDevices; deviceIndex++)
+                    if (handleAsioBuffer)
                     {
-                        if (deviceContext->RenderStreamEngine[deviceIndex] != nullptr)
-                        {
-                            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - buffer index %u, transfer object %p", bufIndex, m_outputBuffers[bufIndex].TransferObject);
-                            deviceContext->RtPacketObject->CopyFromRtPacketToOutputData(
-                                deviceIndex,
+                        if (!NT_SUCCESS(deviceContext->AsioBufferObject->CopyFromAsioToOutputData(
                                 outBufferStart,
                                 transferSize,
-                                m_outputBuffers[bufIndex].TotalProcessedBytesSoFar,
-                                m_outputBuffers[bufIndex].TransferObject,
-                                deviceContext->AudioProperty.OutputBytesPerSample /* ex: 3 */,
-                                deviceContext->AudioProperty.OutputValidBitsPerSample /* ex: 24*/,
-                                deviceContext->OutputUsbChannels
-                            );
+                                bytesPerBlock,
+                                deviceContext->AudioProperty.OutputBytesPerSample
+                            )))
+                        {
+                            StreamObject::ClearOutputBuffer(deviceContext->AudioProperty.CurrentSampleFormat, outBufferStart, outChannels, bytesPerBlock, samples);
+                        }
+                    }
+
+                    if (deviceContext->RtPacketObject != nullptr)
+                    {
+                        for (ULONG deviceIndex = 0; deviceIndex < deviceContext->NumOfOutputDevices; deviceIndex++)
+                        {
+                            if (deviceContext->RenderStreamEngine[deviceIndex] != nullptr)
+                            {
+                                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - buffer index %u, transfer object %p", bufIndex, m_outputBuffers[bufIndex].TransferObject);
+                                deviceContext->RtPacketObject->CopyFromRtPacketToOutputData(
+                                    deviceIndex,
+                                    outBufferStart,
+                                    transferSize,
+                                    m_outputBuffers[bufIndex].TotalProcessedBytesSoFar,
+                                    m_outputBuffers[bufIndex].TransferObject,
+                                    deviceContext->AudioProperty.OutputBytesPerSample /* ex: 3 */,
+                                    deviceContext->AudioProperty.OutputValidBitsPerSample /* ex: 24*/,
+                                    deviceContext->OutputUsbChannels
+                                );
+                            }
                         }
                     }
                 }
@@ -1840,7 +1911,7 @@ void StreamObject::MixingEngineThreadMain(
         }
         if (deviceContext->AsioBufferObject != nullptr && deviceContext->AsioBufferObject->IsRecBufferReady())
         {
-            if (deviceContext->AsioBufferObject->EvaluatePositionAndNotifyIfNeeded(currentTimePCUs, lastAsioNotifyPCUs, asioNotifyCount, prevAsioMeasuredPeriodUs, curClientProcessingTimeUs, curAsioMeasuredPeriodUs))
+            if (deviceContext->AsioBufferObject->EvaluatePositionAndNotifyIfNeeded(currentTimePCUs, lastAsioNotifyPCUs, asioNotifyCount, prevAsioMeasuredPeriodUs, curClientProcessingTimeUs, curAsioMeasuredPeriodUs, hasInputIsochronousInterface, hasOutputIsochronousInterface))
             {
                 m_asioElapsedTimeUs = 0;
                 prevAsioMeasuredPeriodUs = curAsioMeasuredPeriodUs;

--- a/src/uac2-driver/StreamObject.h
+++ b/src/uac2-driver/StreamObject.h
@@ -127,7 +127,12 @@ class StreamObject
   public:
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
-    StreamObject(_In_ PDEVICE_CONTEXT deviceContext);
+    StreamObject(
+        _In_ PDEVICE_CONTEXT      deviceContext,
+        _In_ const StreamStatuses ioStable,
+        _In_ const StreamStatuses ioStreaming,
+        _In_ const StreamStatuses ioSteady
+    );
 
     virtual __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
@@ -319,7 +324,10 @@ class StreamObject
     static __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     StreamObject * Create(
-        _In_ PDEVICE_CONTEXT deviceContext
+        _In_ PDEVICE_CONTEXT      deviceContext,
+        _In_ const StreamStatuses ioStable,
+        _In_ const StreamStatuses ioStreaming,
+        _In_ const StreamStatuses ioSteady
     );
 
   private:
@@ -425,9 +433,14 @@ class StreamObject
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     bool
-    IsOutputPacketAtEstimatedPosition(
+    IsOutputPacketOverlapWithEstimatePosition(
         _In_ ULONG inOffset
     );
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    bool
+    IsOutputPacketAtEstimatedPosition();
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
@@ -587,6 +600,10 @@ class StreamObject
 
     BUFFER_PROPERTY m_inputBuffers[UAC_MAX_IRP_NUMBER * UAC_MAX_CLASSIC_FRAMES_PER_IRP * 8]{};
     BUFFER_PROPERTY m_outputBuffers[UAC_MAX_IRP_NUMBER * UAC_MAX_CLASSIC_FRAMES_PER_IRP * 8]{};
+
+    const StreamStatuses c_ioStable;
+    const StreamStatuses c_ioStreaming;
+    const StreamStatuses c_ioSteady;
 };
 
 #endif

--- a/src/uac2-driver/TransferObject.cpp
+++ b/src/uac2-driver/TransferObject.cpp
@@ -1160,7 +1160,18 @@ ULONG TransferObject::GetFeedbackSum(ULONG & validFeedback)
     {
 
         PUCHAR inBuffer = (PUCHAR)(m_dataBuffer) + m_urb->UrbIsochronousTransfer.IsoPacket[i].Offset;
-        ULONG  feedbackValue = *(PULONG)inBuffer;
+        ULONG  feedbackValue = 0;
+
+        if (m_urb->UrbIsochronousTransfer.IsoPacket[i].Length == 3)
+        {
+            // If the length is 3 bytes, the value is treated as a 24-bit fixed-point number in 10.14 format.
+            feedbackValue = ((ULONG)inBuffer[0]) | (((ULONG)inBuffer[1]) << 8) | (((ULONG)inBuffer[2]) << 16);
+        }
+        else
+        {
+            // If the length is any other value, the value is treated as a 32-bit fixed-point number in 16.16 format.
+            feedbackValue = *(PULONG)inBuffer;
+        }
         if (m_lockDelayCount != 0)
         {
             TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, "feedback frame %u, value %08x, LOCK DELAY ENABLED.", m_urb->UrbIsochronousTransfer.StartFrame, feedbackValue);

--- a/src/uac2-driver/USBAudioConfiguration.h
+++ b/src/uac2-driver/USBAudioConfiguration.h
@@ -1465,7 +1465,26 @@ class USBAudioConfiguration
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     NTSTATUS
+    GetStreamChannelInfoAdjusted(
+        _In_ bool      isInput,
+        _Out_ UCHAR &  numOfChannels,
+        _Out_ USHORT & terminalType,
+        _Out_ UCHAR &  volumeUnitID,
+        _Out_ UCHAR &  muteUnitID
+    );
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    NTSTATUS
     GetStreamDevices(
+        _In_ bool     isInput,
+        _Out_ ULONG & numOfDevices
+    );
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    NTSTATUS
+    GetStreamDevicesAdjusted(
         _In_ bool     isInput,
         _Out_ ULONG & numOfDevices
     );

--- a/src/uac2-driver/USBAudioConfiguration.h
+++ b/src/uac2-driver/USBAudioConfiguration.h
@@ -550,6 +550,10 @@ class USBAudioStreamInterface : public USBAudioInterface
     PAGED_CODE_SEG
     virtual ULONG GetLockDelay();
 
+    virtual bool HasInputIsochronousEndpoint() = 0;
+
+    virtual bool HasOutputIsochronousEndpoint() = 0;
+
     virtual bool HasFeedbackEndpoint() = 0;
 
     virtual UCHAR GetFeedbackEndpointAddress() = 0;
@@ -798,6 +802,14 @@ class USBAudio1StreamInterface : public USBAudioStreamInterface
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     virtual UCHAR GetBytesPerSample();
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    virtual bool HasInputIsochronousEndpoint();
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    virtual bool HasOutputIsochronousEndpoint();
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
@@ -1161,6 +1173,14 @@ class USBAudio2StreamInterface : public USBAudioStreamInterface
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
+    virtual bool HasInputIsochronousEndpoint();
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    virtual bool HasOutputIsochronousEndpoint();
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
     virtual bool HasFeedbackEndpoint();
 
     __drv_maxIRQL(PASSIVE_LEVEL)
@@ -1250,7 +1270,15 @@ class USBAudioInterfaceInfo
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
-    NTSTATUS StoreInterface(USBAudioInterface * interface);
+    NTSTATUS StoreInterface(
+        _In_ USBAudioInterface * interface
+    );
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
+    NTSTATUS GetInterfaceNumber(
+        _Out_ ULONG & interfaceNumber
+    );
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
@@ -1499,6 +1527,13 @@ class USBAudioConfiguration
 
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
+    NTSTATUS
+    GetNearestSupportedSampleRate(
+        _Inout_ ULONG & sampleRate
+    );
+
+    __drv_maxIRQL(PASSIVE_LEVEL)
+    PAGED_CODE_SEG
     USBAudioDataFormatManager *
     GetUSBAudioDataFormatManager(
         _In_ bool isInput
@@ -1513,6 +1548,18 @@ class USBAudioConfiguration
     __drv_maxIRQL(PASSIVE_LEVEL)
     PAGED_CODE_SEG
     bool isUSBAudio2() const;
+
+    __drv_maxIRQL(DISPATCH_LEVEL)
+    NONPAGED_CODE_SEG
+    bool hasInputIsochronousInterface() const;
+
+    __drv_maxIRQL(DISPATCH_LEVEL)
+    NONPAGED_CODE_SEG
+    bool hasOutputIsochronousInterface() const;
+
+    __drv_maxIRQL(DISPATCH_LEVEL)
+    NONPAGED_CODE_SEG
+    bool hasInputAndOutputIsochronousInterfaces() const;
 
     static __drv_maxIRQL(DISPATCH_LEVEL)
     PAGED_CODE_SEG
@@ -1648,6 +1695,8 @@ class USBAudioConfiguration
     USBAudioInterfaceInfo **      m_usbAudioInterfaceInfoes{nullptr};
     WDFMEMORY                     m_usbAudioInterfaceInfoesMemory{nullptr};
     bool                          m_isUSBAudio2{false};
+    bool                          m_isInputIsochronousInterfaceExists{false};
+    bool                          m_isOutputIsochronousInterfaceExists{false};
     USBAudioDataFormatManager     m_inputUsbAudioDataFormatManager;
     USBAudioDataFormatManager     m_outputUsbAudioDataFormatManager;
 };


### PR DESCRIPTION
## Summary
 
This Pull Request introduces two key enhancements:
 
1. Support for devices with input-only or output-only audio interfaces
2. Support for full-speed USB devices using 3-byte explicit feedback packets
 
## Purpose
 
These changes enable proper operation of ACX Audio and ASIO with devices such as the Apple AirPods Max (USB-C).
 
## Details
 
- Added initialization, audio transfer handling, and ASIO driver support for USB audio devices that have either input or output channels only.
- Implemented handling of 3-byte explicit feedback packets for full-speed USB devices.
 
---
 
Thank you for reviewing this contribution.