### PR TITLE
Fix Code 10 error on devices mixing USB Audio 2.0 and USB Audio 1.0 interfaces

### DIFF
--- a/src/uac2-driver/USBAudioConfiguration.h
+++ b/src/uac2-driver/USBAudioConfiguration.h
@@ -1778,7 +1778,7 @@ class USBAudioConfiguration
     PAGED_CODE_SEG
     NTSTATUS CreateInterface(
         _In_ const PUSB_INTERFACE_DESCRIPTOR descriptor,
-        _Out_ USBAudioInterface *&           usbAudioInterface
+        _Inout_ USBAudioInterface *&         usbAudioInterface
     );
 
     __drv_maxIRQL(PASSIVE_LEVEL)


### PR DESCRIPTION
## Summary

This Pull Request provides a fix for the issue reported in  
https://github.com/microsoft/low-latency-audio/issues/18:  
**"[BUG]: Error code 10 with Motu M4 #18"**.

## Details

This update resolves a problem where devices that mix USB Audio 2.0 and USB Audio 1.0 interfaces—such as the Motu M4—could fail to start and report Error Code 10 during driver initialization.

The fix is included in the following commit:

- Fix: Resolve Code 10 error on devices mixing USB Audio 2.0 and USB Audio 1.0 interfaces

## Related Issue

Related to Issue #18

---

Thank you for reviewing this contribution.