### PR TITLE
Fix ASIO/WASAPI issues, add packet size constraints, and align INF formatting

### DIFF
--- a/src/uac2-driver/CaptureCircuit.cpp
+++ b/src/uac2-driver/CaptureCircuit.cpp
@@ -1097,16 +1097,18 @@ PAGED_CODE_SEG
 NTSTATUS
 CodecC_EvtCircuitPowerUp(
     _In_ WDFDEVICE /* Device */,
-    _In_ ACXCIRCUIT /* Circuit */,
+    _In_ ACXCIRCUIT  Circuit ,
     _In_ WDF_POWER_DEVICE_STATE /* PreviousState */
 )
 {
     PAGED_CODE();
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Entry");
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Exit");
+    NTSTATUS status = AddPropertyToCircuitInterface(Circuit, ARRAYSIZE(c_InterfaceProperties), c_InterfaceProperties);
 
-    return STATUS_SUCCESS;
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Exit %!STATUS!", status);
+
+    return status;
 }
 
 _Use_decl_annotations_

--- a/src/uac2-driver/CaptureCircuit.cpp
+++ b/src/uac2-driver/CaptureCircuit.cpp
@@ -1174,6 +1174,17 @@ Return Value:
 
     // ASSERT(IsEqualGUID(*SignalProcessingMode, AUDIO_SIGNALPROCESSINGMODE_RAW));
 
+    ACXDATAFORMAT selectedDataFormat = StreamFormat;
+    if (GetFormatTagFromAcxDataFormat(StreamFormat) != WAVE_FORMAT_EXTENSIBLE)
+    {
+        status = ConvertWaveFormatExToWaveFormatExtensible(Device, Circuit, StreamFormat, selectedDataFormat);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "ConvertWaveFormatExToWaveFormatExtensible %!STATUS!", status);
+        if (!NT_SUCCESS(status))
+        {
+            return status;
+        }
+    }
+
     deviceContext = GetDeviceContext(Device);
     ASSERT(deviceContext != nullptr);
 
@@ -1195,7 +1206,7 @@ Return Value:
         ACXDATAFORMAT stereoDataFormat;
         RETURN_NTSTATUS_IF_FAILED(SplitAcxDataFormatByDeviceChannels(Device, Circuit, pinContext->NumOfChannelsPerDevice, stereoDataFormat, dataFormat));
 
-        if (!AcxDataFormatIsEqual(stereoDataFormat, StreamFormat))
+        if (!AcxDataFormatIsEqual(stereoDataFormat, selectedDataFormat))
         {
             status = STATUS_NOT_SUPPORTED;
             TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Exit %!STATUS!", status);
@@ -1246,7 +1257,7 @@ Return Value:
     // Create the virtual streaming engine which will control
     // streaming logic for the capture circuit.
     //
-    streamEngine = new (POOL_FLAG_NON_PAGED, DRIVER_TAG) CCaptureStreamEngine(deviceContext, stream, StreamFormat, pinContext->DeviceIndex, pinContext->Channel, pinContext->NumOfChannelsPerDevice);
+    streamEngine = new (POOL_FLAG_NON_PAGED, DRIVER_TAG) CCaptureStreamEngine(deviceContext, stream, selectedDataFormat, pinContext->DeviceIndex, pinContext->Channel, pinContext->NumOfChannelsPerDevice);
     RETURN_NTSTATUS_IF_TRUE(streamEngine == nullptr, STATUS_INSUFFICIENT_RESOURCES);
 
     streamContext->StreamEngine = (PVOID)streamEngine;

--- a/src/uac2-driver/CircuitHelper.cpp
+++ b/src/uac2-driver/CircuitHelper.cpp
@@ -21,7 +21,7 @@ Environment:
     Kernel mode
 
 --*/
-
+#include <initguid.h>
 #include "Private.h"
 #include "Public.h"
 #include "CircuitHelper.h"
@@ -751,4 +751,73 @@ void TraceAcxDataFormat(
         TraceEvents(DebugPrintLevel, TRACE_DEVICE, " - WAVEFORMATEX::wBitsPerSample  %u", waveFormatEx->wBitsPerSample);
         TraceEvents(DebugPrintLevel, TRACE_DEVICE, " - WAVEFORMATEX::cbSize          %u", waveFormatEx->cbSize);
     }
+}
+
+_Use_decl_annotations_
+PAGED_CODE_SEG
+NTSTATUS AddPropertyToCircuitInterface(
+    ACXCIRCUIT              Circuit,
+    ULONG                   PropertyCount,
+    const DSP_DEVPROPERTY*  Properties
+)
+{
+    PAGED_CODE();
+
+    NTSTATUS        status = STATUS_UNSUCCESSFUL;
+    UNICODE_STRING  acxLink = { 0 };
+    UNICODE_STRING  audioLink = { 0 };
+    WDFSTRING       wdfLink = AcxCircuitGetSymbolicLinkName(Circuit);
+    bool            freeStr = false;
+
+    auto exit = wil::scope_exit(
+        [&]() {
+            if (freeStr)
+            {
+                RtlFreeUnicodeString(&audioLink);
+                freeStr = false;
+            }
+        }
+    );
+
+    // Get the underline unicode string.
+    WdfStringGetUnicodeString(wdfLink, &acxLink);
+
+    // Make sure there is a string.
+    if (!acxLink.Length || !acxLink.Buffer)
+    {
+        status = STATUS_INVALID_DEVICE_STATE;
+        return status;
+    }
+
+    // Get the audio interface.
+    status = IoGetDeviceInterfaceAlias(&acxLink, &KSCATEGORY_AUDIO, &audioLink);
+    if (!NT_SUCCESS(status))
+    {
+        return status;
+    }
+
+    freeStr = true;
+
+    // Set specified properties on the audio interface for the ACXCIRCUIT.
+    for (ULONG i = 0; i < PropertyCount; ++i)
+    {
+        status = IoSetDeviceInterfacePropertyData(
+            &audioLink,
+            Properties[i].PropertyKey,
+            LOCALE_NEUTRAL,
+            PLUGPLAY_PROPERTY_PERSISTENT,
+            Properties[i].Type,
+            Properties[i].BufferSize,
+            Properties[i].Buffer
+        );
+
+        if (!NT_SUCCESS(status))
+        {
+            return status;
+        }
+    }
+
+    status = STATUS_SUCCESS;
+
+    return status;
 }

--- a/src/uac2-driver/CircuitHelper.cpp
+++ b/src/uac2-driver/CircuitHelper.cpp
@@ -752,3 +752,53 @@ void TraceAcxDataFormat(
         TraceEvents(DebugPrintLevel, TRACE_DEVICE, " - WAVEFORMATEX::cbSize          %u", waveFormatEx->cbSize);
     }
 }
+
+PAGED_CODE_SEG
+WORD GetFormatTagFromAcxDataFormat(
+    _In_    ACXDATAFORMAT   DataFormat
+)
+{
+    PAGED_CODE();
+    PWAVEFORMATEX waveFormatEx = (PWAVEFORMATEX)AcxDataFormatGetWaveFormatEx(DataFormat);
+    return waveFormatEx->wFormatTag;
+}
+
+PAGED_CODE_SEG
+NTSTATUS ConvertWaveFormatExToWaveFormatExtensible
+(
+    _In_    WDFDEVICE       Device,
+    _In_    ACXCIRCUIT      Circuit,
+    _In_    ACXDATAFORMAT   DataFormatEx,
+    _Out_   ACXDATAFORMAT& DataFormatExtensible
+)
+{
+    PAGED_CODE();
+
+    if (GetFormatTagFromAcxDataFormat(DataFormatEx) == WAVE_FORMAT_EXTENSIBLE)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    KSDATAFORMAT_WAVEFORMATEXTENSIBLE ksDataFormatExtensible;
+    RtlZeroMemory(&ksDataFormatExtensible, sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE));
+
+    PKSDATAFORMAT_WAVEFORMATEX ksDataFormatEx = (PKSDATAFORMAT_WAVEFORMATEX)AcxDataFormatGetKsDataFormat(DataFormatEx);
+    RtlCopyMemory(&ksDataFormatExtensible, ksDataFormatEx, sizeof(KSDATAFORMAT_WAVEFORMATEX));
+
+    ksDataFormatExtensible.WaveFormatExt.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
+    ksDataFormatExtensible.WaveFormatExt.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+    ksDataFormatExtensible.WaveFormatExt.Samples.wValidBitsPerSample = ksDataFormatEx->WaveFormatEx.wBitsPerSample;
+
+    if (ksDataFormatEx->WaveFormatEx.nChannels < 2)
+    {
+        ksDataFormatExtensible.WaveFormatExt.dwChannelMask = KSAUDIO_SPEAKER_MONO;
+    }
+    else
+    {
+        ksDataFormatExtensible.WaveFormatExt.dwChannelMask = KSAUDIO_SPEAKER_STEREO;
+    }
+
+    INIT_WAVEFORMATEX_GUID(&ksDataFormatExtensible.WaveFormatExt.SubFormat, ksDataFormatEx->WaveFormatEx.wFormatTag);
+
+    return AllocateFormat(&ksDataFormatExtensible, Circuit, Device, &DataFormatExtensible);
+}

--- a/src/uac2-driver/CircuitHelper.h
+++ b/src/uac2-driver/CircuitHelper.h
@@ -146,3 +146,17 @@ void TraceAcxDataFormat(
     _In_ UCHAR         DebugPrintLevel,
     _In_ ACXDATAFORMAT DataFormat
 );
+
+PAGED_CODE_SEG
+WORD GetFormatTagFromAcxDataFormat(
+    _In_    ACXDATAFORMAT   DataFormat
+);
+
+PAGED_CODE_SEG
+NTSTATUS ConvertWaveFormatExToWaveFormatExtensible
+(
+    _In_    WDFDEVICE       Device,
+    _In_    ACXCIRCUIT      Circuit,
+    _In_    ACXDATAFORMAT   DataFormatEx,
+    _Out_   ACXDATAFORMAT& DataFormatExtensible
+);

--- a/src/uac2-driver/CircuitHelper.h
+++ b/src/uac2-driver/CircuitHelper.h
@@ -53,6 +53,51 @@ typedef NTSTATUS(EVT_KSATTRIBUTES_VISITOR)(
 
 typedef EVT_KSATTRIBUTES_VISITOR * PFN_KSATTRIBUTES_VISITOR;
 
+#define HNSTIME_PER_MILLISECOND 10000
+
+typedef struct _DSP_DEVPROPERTY {
+    const DEVPROPKEY* PropertyKey;
+    DEVPROPTYPE Type;
+    ULONG BufferSize;
+    __field_bcount_opt(BufferSize) PVOID Buffer;
+} DSP_DEVPROPERTY, PDSP_DEVPROPERTY;
+
+static struct
+{
+    KSAUDIO_PACKETSIZE_CONSTRAINTS2                 TransportPacketConstraints;         // 1
+    KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT    AdditionalProcessingConstraints[1]; // 1 + 1 = 2
+} s_PacketSizeConstraints =
+{
+    {
+        ULONG(7.0 * (double)HNSTIME_PER_MILLISECOND),           // 7 ms minimum processing interval
+        FILE_BYTE_ALIGNMENT,                                    // 1 byte packet size alignment
+        0,                                                      // no maximum packet size constraint
+        2,                                                      // 2 processing constraints follow
+        {
+            STATIC_AUDIO_SIGNALPROCESSINGMODE_RAW,              // constraint for raw processing mode
+            0,                                                  // NA samples per processing frame
+            ULONG(7.0 * (double)HNSTIME_PER_MILLISECOND),       // 70000 hns (7ms) per processing frame
+        }
+    },
+    {
+        {
+            STATIC_AUDIO_SIGNALPROCESSINGMODE_DEFAULT,          // constraint for default processing mode
+            0,                                                  // NA samples per processing frame
+            ULONG(7.0 * (double)HNSTIME_PER_MILLISECOND),       // 70000 hns (7ms) per processing frame
+        }
+    }
+};
+
+const DSP_DEVPROPERTY c_InterfaceProperties[] =
+{
+    {
+        &DEVPKEY_KsAudio_PacketSize_Constraints2,       // Key
+        DEVPROP_TYPE_BINARY,                            // Type
+        sizeof(s_PacketSizeConstraints),                // BufferSize
+        &s_PacketSizeConstraints,                       // Buffer
+    },
+};
+
 PAGED_CODE_SEG
 NTSTATUS AllocateFormat(
     _In_ KSDATAFORMAT_WAVEFORMATEXTENSIBLE * WaveFormat,
@@ -145,4 +190,11 @@ PAGED_CODE_SEG
 void TraceAcxDataFormat(
     _In_ UCHAR         DebugPrintLevel,
     _In_ ACXDATAFORMAT DataFormat
+);
+
+PAGED_CODE_SEG
+NTSTATUS AddPropertyToCircuitInterface(
+    _In_ ACXCIRCUIT             Circuit,
+    _In_ ULONG                  PropertyCount,
+    _In_ const DSP_DEVPROPERTY* Properties
 );

--- a/src/uac2-driver/Device.cpp
+++ b/src/uac2-driver/Device.cpp
@@ -5784,41 +5784,28 @@ VOID EvtUSBAudioAcxDriverSetBufferPeriod(
 
     if (*bufferPeriod != deviceContext->Params.SuggestedBufferPeriod)
     {
-
-        if ((deviceContext->StartCounterAsio != 0) || (deviceContext->StartCounterWdmAudio != 0))
+        if (deviceContext->AsioOwner != nullptr)
         {
-            StopIsoStream(deviceContext);
-        }
 
-        status = UpdateFramePerIrp(deviceContext, *bufferPeriod);
-        ASSERT(NT_SUCCESS(status));
-
-        status = UpdateBufferOperationOffset(deviceContext, *bufferPeriod);
-        ASSERT(NT_SUCCESS(status));
-
-        deviceContext->Params.SuggestedBufferPeriod = *bufferPeriod;
-
-        status = ActivateAudioInterface(
-            deviceContext,
-            deviceContext->AudioProperty.SampleRate,
-            NS_USBAudio0200::FORMAT_TYPE_I,
-            NS_USBAudio0200::PCM,
-            deviceContext->InputProperty.BytesPerSample,
-            deviceContext->InputProperty.ValidBitsPerSample,
-            deviceContext->OutputProperty.BytesPerSample,
-            deviceContext->OutputProperty.ValidBitsPerSample
-        );
-
-        if (NT_SUCCESS(status))
-        {
             if ((deviceContext->StartCounterAsio != 0) || (deviceContext->StartCounterWdmAudio != 0))
             {
-                StartIsoStream(deviceContext);
+                StopIsoStream(deviceContext);
             }
-            else
-            {
-                ASSERT(NT_SUCCESS(status));
-            }
+
+            status = UpdateFramePerIrp(deviceContext, *bufferPeriod);
+            ASSERT(NT_SUCCESS(status));
+
+            status = UpdateBufferOperationOffset(deviceContext, *bufferPeriod);
+            ASSERT(NT_SUCCESS(status));
+
+            deviceContext->Params.SuggestedBufferPeriod = *bufferPeriod;
+
+            deviceContext->AsioBufferObject->SetRecDeviceStatus(DeviceStatuses::ResetRequired);
+        }
+        else
+        {
+            deviceContext->Params.SuggestedBufferPeriod = *bufferPeriod;
+            status = STATUS_SUCCESS;
         }
     }
     else

--- a/src/uac2-driver/RenderCircuit.cpp
+++ b/src/uac2-driver/RenderCircuit.cpp
@@ -1363,6 +1363,17 @@ Return Value:
 
     // ASSERT(IsEqualGUID(*SignalProcessingMode, AUDIO_SIGNALPROCESSINGMODE_RAW));
 
+    ACXDATAFORMAT selectedDataFormat = StreamFormat;
+    if (GetFormatTagFromAcxDataFormat(StreamFormat) != WAVE_FORMAT_EXTENSIBLE)
+    {
+        status = ConvertWaveFormatExToWaveFormatExtensible(Device, Circuit, StreamFormat, selectedDataFormat);
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "ConvertWaveFormatExToWaveFormatExtensible %!STATUS!", status);
+        if (!NT_SUCCESS(status))
+        {
+            return status;
+        }
+    }
+
     ASSERT(Circuit != nullptr);
     circuitContext = GetRenderCircuitContext(Circuit);
     ASSERT(circuitContext);
@@ -1388,7 +1399,7 @@ Return Value:
         ACXDATAFORMAT stereoDataFormat;
         RETURN_NTSTATUS_IF_FAILED(SplitAcxDataFormatByDeviceChannels(Device, Circuit, pinContext->NumOfChannelsPerDevice, stereoDataFormat, dataFormat));
 
-        if (!AcxDataFormatIsEqual(stereoDataFormat, StreamFormat))
+        if (!AcxDataFormatIsEqual(stereoDataFormat, selectedDataFormat))
         {
             status = STATUS_NOT_SUPPORTED;
             TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Exit %!STATUS!", status);
@@ -1436,7 +1447,7 @@ Return Value:
     // Create the virtual streaming engine which will control
     // streaming logic for the render circuit.
     //
-    renderStreamEngine = new (POOL_FLAG_NON_PAGED, DRIVER_TAG) CRenderStreamEngine(deviceContext, stream, StreamFormat, pinContext->DeviceIndex, pinContext->Channel, pinContext->NumOfChannelsPerDevice, FALSE /* , nullptr */);
+    renderStreamEngine = new (POOL_FLAG_NON_PAGED, DRIVER_TAG) CRenderStreamEngine(deviceContext, stream, selectedDataFormat, pinContext->DeviceIndex, pinContext->Channel, pinContext->NumOfChannelsPerDevice, FALSE /* , nullptr */);
     RETURN_NTSTATUS_IF_TRUE(renderStreamEngine == nullptr, STATUS_INSUFFICIENT_RESOURCES);
 
     streamContext = GetStreamEngineContext(stream);

--- a/src/uac2-driver/RenderCircuit.cpp
+++ b/src/uac2-driver/RenderCircuit.cpp
@@ -1287,14 +1287,18 @@ PAGED_CODE_SEG
 NTSTATUS
 CodecR_EvtCircuitPowerUp(
     _In_ WDFDEVICE /* Device */,
-    _In_ ACXCIRCUIT /* Circuit */,
+    _In_ ACXCIRCUIT  Circuit,
     _In_ WDF_POWER_DEVICE_STATE /* PreviousState */
 )
 {
     PAGED_CODE();
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Entry");
 
-    return STATUS_SUCCESS;
+    NTSTATUS status = AddPropertyToCircuitInterface(Circuit, ARRAYSIZE(c_InterfaceProperties), c_InterfaceProperties);
+
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CIRCUIT, "%!FUNC! Exit %!STATUS!", status);
+
+    return status;
 }
 
 _Use_decl_annotations_

--- a/src/uac2-driver/USBAudio2-ACX.inf
+++ b/src/uac2-driver/USBAudio2-ACX.inf
@@ -1,6 +1,10 @@
+; Copyright (c) Microsoft Corporation.
 ; Copyright (c) Yamaha Corporation.
-; Licensed under the terms of the MIT license:
-; https://github.com/microsoft/low-latency-audio/blob/main/LICENSE
+; Licensed under the MIT License
+; ============================================================================
+; This is part of the Microsoft Low-Latency Audio driver project.
+; Further information: https://aka.ms/asio
+; ============================================================================
 ;
 ; USBAudio2-ACX.inf
 ;


### PR DESCRIPTION
## Summary
- Fix issues in the ASIO and WASAPI paths.
- Add packet size constraints as part of the low-latency shared mode work.
- Align INF file formatting with the rest of the project.

## Details
- Invoke ASIO reset when the buffer size changes during ASIO streaming to prevent noise.
- Convert WAVEFORMATEX to WAVEFORMATEXTENSIBLE to address the BSOD reported in Issue #21. 【1-f960b5】
- Add packet size constraints and helper functions as part of the ongoing work for Issue #22. The current KSAUDIO_PACKETSIZE_CONSTRAINTS2 values are temporary and may be refined later. 【2-0b35ea】
- Align the INF copyright notice format with the other source files.

---
Thank you for reviewing this contribution.
