### PR TITLE
Fix: Remove absolute paths and include the files necessary for the USBAsioControlPanel

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -125,7 +125,7 @@ foreach($configuration in $configurations)
         #New-Item -Path $stagingTargetFolder -ItemType Directory
 
             # copy output files to staging
-        Copy-Item -Path "$controlPanelOutputFolder*.exe" -Destination $stagingTargetFolder
+        Copy-Item -Path "$controlPanelOutputFolder*" -Destination $stagingTargetFolder -Recurse
 
         Write-Host
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,6 +1,7 @@
 Write-Host "This must be run in a command prompt with MSBuild and other tools paths set. For example, the Developer Command Prompt for VS2022"
 
-$repoRoot = "G:\Github\microsoft\low-latency-audio\"
+$scriptDir = $PSScriptRoot
+$repoRoot = (Resolve-Path (Split-Path $scriptDir -Parent)).Path.TrimEnd('\') + '\'
 $sourceRoot = $repoRoot + "src\"
 $vsfilesFolder = $sourceRoot + "vsfiles\"
 $vsfilesFolderOut = $vsfilesFolder + "out\"

--- a/src/installer/uac2-acx-installer.wxs
+++ b/src/installer/uac2-acx-installer.wxs
@@ -1,6 +1,6 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
-  <?define StagingSourceRootFolder=G:\Github\microsoft\low-latency-audio\build\staging ?>
+  <?define StagingSourceRootFolder=$(var.ProjectDir)\..\..\build\staging ?>
   <?define StagingVersionIncludeFile=$(StagingSourceRootFolder)\version\BundleInfo.wxi ?>
 
   <Package
@@ -15,6 +15,7 @@
 
       <StandardDirectory Id="ProgramFiles64Folder">
           <Directory Id="ROOTINSTALLFOLDER" Name="Windows ASIO">
+            <Directory Id="AssetsFolder" Name="Assets" />
           </Directory>
       </StandardDirectory>
         
@@ -40,11 +41,43 @@
         -->
         
         <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\USBAsioControlPanel.exe" Vital="true" />
+        <!-- WinAppSDK / WinUI3 -->
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Microsoft.WindowsAppRuntime.Bootstrap.dll" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\USBAsioControlPanel.pri" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\USBAsioControlPanel.winmd" />
 
+        <!-- WebView2 -->
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Microsoft.Web.WebView2.Core.dll" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Microsoft.Web.WebView2.Core.winmd" />
+
+        <!-- XAML compiled XBF -->
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\AboutPage.xbf" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\App.xbf" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\AsioPage.xbf" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\MainWindow.xbf" />
+
+      </Component>
+
+      <!-- Assets folder files -->
+      <Component Id="AssetsFiles"
+                 Permanent="no"
+                 Bitness="always64"
+                 Directory="AssetsFolder"
+                 Guid="b1f3c0c1-9d22-4b1e-9f5c-8a7c1c0e1234">
+
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\ASIOLogoIcon2.bmp" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\LockScreenLogo.scale-200.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\SplashScreen.scale-200.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\Square44x44Logo.scale-200.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\Square150x150Logo.scale-200.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\StoreLogo.png" />
+        <File Source="$(StagingSourceRootFolder)\$(var.Platform)\$(var.Configuration)\Assets\Wide310x150Logo.scale-200.png" />
       </Component>
 
       <Feature Id="UsbAcxAndAsioDriver">
           <ComponentRef Id="Driver" />
+          <ComponentRef Id="AssetsFiles" />
       </Feature>
 
   </Package>


### PR DESCRIPTION
## Summary
This PR fixes the build script and the installer packaging by removing absolute paths and ensuring the required files are included.

## Changes
- Removed hardcoded absolute paths
- Updated the installer configuration to use portable paths
- Included the files needed for USBAsioControlPanel in the installer

## Why
Using absolute paths can break build for the driver and the installer on other machines or environments. This change makes the arfifacts and easier to build correctly.

## Notes
No functional changes to the application itself; this update is focused on build script and installer packaging and path handling.