### PR TITLE
Fix: Prevent BSOD from RtPacketsCount race in RtPacketObject

### DIFF
--- a/src/uac2-driver/RtPacketObject.cpp
+++ b/src/uac2-driver/RtPacketObject.cpp
@@ -60,8 +60,14 @@ RtPacketObject::RtPacketObject(
     : m_deviceContext(deviceContext)
 
 {
+    WDF_OBJECT_ATTRIBUTES attributes;
+
     PAGED_CODE();
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%!FUNC! Entry");
+
+    WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
+    attributes.ParentObject = deviceContext->Device;
+    WdfWaitLockCreate(&attributes, &m_rtPacketLock);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%!FUNC! Exit");
 }
@@ -356,13 +362,22 @@ RtPacketObject::SetRtPackets(
     }
 
     RETURN_NTSTATUS_IF_TRUE(deviceIndex >= numOfDevices, STATUS_INVALID_PARAMETER);
-    RETURN_NTSTATUS_IF_TRUE(rtPacketInfo[deviceIndex].RtPackets != nullptr, STATUS_INVALID_DEVICE_STATE);
+
+    WdfWaitLockAcquire(m_rtPacketLock, nullptr);
+
+    if (rtPacketInfo[deviceIndex].RtPackets != nullptr)
+    {
+        WdfWaitLockRelease(m_rtPacketLock);
+        RETURN_NTSTATUS_IF_TRUE(TRUE, STATUS_INVALID_DEVICE_STATE);
+    }
 
     rtPacketInfo[deviceIndex].RtPackets = rtPackets;
     rtPacketInfo[deviceIndex].RtPacketsCount = rtPacketsCount;
     rtPacketInfo[deviceIndex].RtPacketSize = rtPacketSize;
     rtPacketInfo[deviceIndex].UsbChannel = channel;
     rtPacketInfo[deviceIndex].Channels = numOfChannelsPerDevice;
+
+    WdfWaitLockRelease(m_rtPacketLock);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Exit %!STATUS!", status);
 
@@ -394,9 +409,11 @@ void RtPacketObject::UnsetRtPackets(
 
     if (deviceIndex < numOfDevices)
     {
+        WdfWaitLockAcquire(m_rtPacketLock, nullptr);
         rtPacketInfo[deviceIndex].RtPackets = nullptr;
         rtPacketInfo[deviceIndex].RtPacketsCount = 0;
         rtPacketInfo[deviceIndex].RtPacketSize = 0;
+        WdfWaitLockRelease(m_rtPacketLock);
     }
 }
 
@@ -435,6 +452,8 @@ RtPacketObject::CopyFromRtPacketToOutputData(
     ASSERT(m_outputRtPacketInfo[deviceIndex].RtPacketSize != 0);
 
     RT_PACKET_INFO * rtPacketInfo = &(m_outputRtPacketInfo[deviceIndex]);
+
+    WdfWaitLockAcquire(m_rtPacketLock, nullptr);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - TransferredBytesInThisIrp = %u", transferObject->GetTransferredBytesInThisIrp());
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - m_outputRtPacketInfo[deviceIndex].rtPacketSize = %u", m_outputRtPacketInfo[deviceIndex].RtPacketSize);
@@ -686,6 +705,8 @@ RtPacketObject::CopyFromRtPacketToOutputData(
 CopyFromRtPacketToOutputData_Exit:
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%!FUNC! Exit, RtPacketPosition, bytesCopiedSrcData, bytesCopiedUpToBoundary = %llu, %u, %u", rtPacketInfo->RtPacketPosition, bytesCopiedSrcData, bytesCopiedUpToBoundary);
 
+    WdfWaitLockRelease(m_rtPacketLock);
+
     return status;
 }
 
@@ -724,6 +745,8 @@ RtPacketObject::CopyToRtPacketFromInputData(
     ASSERT(m_inputRtPacketInfo[deviceIndex].RtPacketSize != 0);
 
     RT_PACKET_INFO * rtPacketInfo = &(m_inputRtPacketInfo[deviceIndex]);
+
+    WdfWaitLockAcquire(m_rtPacketLock, nullptr);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - TransferredBytesInThisIrp = %u", transferObject->GetTransferredBytesInThisIrp());
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE, " - m_inputRtPacketInfo[deviceIndex].rtPacketSize = %u", m_inputRtPacketInfo[deviceIndex].RtPacketSize);
@@ -907,6 +930,8 @@ RtPacketObject::CopyToRtPacketFromInputData(
 
 CopyToRtPacketFromInputData_Exit:
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE, "%!FUNC! Exit, RtPacketPosition, bytesCopiedUpToBoundary, bytesCopiedDstData = %llu, %u, %u", rtPacketInfo->RtPacketPosition, bytesCopiedUpToBoundary, bytesCopiedDstData);
+
+    WdfWaitLockRelease(m_rtPacketLock);
 
     return status;
 }

--- a/src/uac2-driver/RtPacketObject.h
+++ b/src/uac2-driver/RtPacketObject.h
@@ -209,6 +209,8 @@ class RtPacketObject
     ULONG         m_outputPaddingBytes{0};
     DWORD         m_inputAvgBytesPerSec{0};
     DWORD         m_outputAvgBytesPerSec{0};
+
+    WDFWAITLOCK m_rtPacketLock{nullptr};
 };
 
 #endif


### PR DESCRIPTION
## Summary

Fixes a `0x1000007E` (`SYSTEM_THREAD_EXCEPTION_NOT_HANDLED`) BSOD caused by an integer divide-by-zero (`STATUS_INTEGER_DIVIDE_BY_ZERO`, `0xC0000094`) inside the mixing thread. A kernel minidump (attached, `081826-11625-01.dmp`) captured while a USB Audio 2.0 render stream was active on `USBAudio2-ACX.sys` was analyzed with WinDbg to identify the exact faulting instruction and root cause.

## Crash analysis (from the attached dump)

`!analyze -v` against the dump (with local build symbols) resolved the fault precisely:

```
BUGCHECK_CODE:  7e
BUGCHECK_P1:    ffffffffc0000094   (STATUS_INTEGER_DIVIDE_BY_ZERO)
BUGCHECK_P2:    fffff8043692a020

EXCEPTION_RECORD: ...
ExceptionAddress: fffff8043692a020 (USBAudio2_ACX!RtPacketObject::CopyFromRtPacketToOutputData+0xcb0)
ExceptionCode: c0000094 (Integer divide-by-zero)

fffff804`3692a020 43f7743e08      div     eax,dword ptr [r14+r15+8]

FAULTING_SOURCE_LINE:        RtPacketObject.cpp
FAULTING_SOURCE_LINE_NUMBER: 556

STACK_TEXT:
USBAudio2_ACX!RtPacketObject::CopyFromRtPacketToOutputData+0xcb0
USBAudio2_ACX!StreamObject::MixingEngineThreadMain+0x1448
USBAudio2_ACX!StreamObject::MixingEngineThreadFunction+0xa0
USBAudio2_ACX!MixingEngineThread::ThreadMain+0x1f3
USBAudio2_ACX!WorkerThread::ThreadRoutine+0x11
nt!PspSystemThreadStartup+0x5a
```

The divisor operand `[r14+r15+8]` lines up exactly with the `RtPacketsCount` field offset (8 bytes, right after the leading `PVOID* RtPackets`) in `RT_PACKET_INFO` (`RtPacketObject.h`), confirming the crashing statement is:

```cpp
rtPacketIndex %= rtPacketInfo->RtPacketsCount;   // RtPacketObject.cpp:556
```

with `RtPacketsCount == 0` at the moment of the modulo.

## Why

`RtPacketObject::UnsetRtPackets()` resets `RtPackets` / `RtPacketsCount` / `RtPacketSize` to zero when a stream's RtPacket buffers are freed (`EvtStreamFreeRtPackets` → `CStreamEngine::FreeRtPackets` → `USBAudioAcxDriverStreamUnsetRtPackets`). This path is serialized only by `DEVICE_CONTEXT::StreamWaitLock`.

`RtPacketObject::CopyFromRtPacketToOutputData()` / `CopyToRtPacketFromInputData()` are called from the mixing/capture thread (`StreamObject::MixingEngineThreadMain`) while holding a *different* lock, `DEVICE_CONTEXT::StreamEngineWaitLock`. These functions read `RtPacketsCount` (and `RtPackets`) repeatedly across their copy loop and divide/modulo by it.

Because `StreamWaitLock` and `StreamEngineWaitLock` do not exclude each other, there is a window where:
1. The mixing thread checks `RenderStreamEngine[deviceIndex]->GetCurrentState() == AcxStreamStateRun` and enters `CopyFromRtPacketToOutputData`.
2. Concurrently, `UnsetRtPackets` runs (e.g., stream teardown, or a re-`AllocateRtPackets` failure path in `CStreamEngine::AllocateRtPackets` that calls `FreeRtPackets` on error) and zeroes `RtPacketsCount`.
3. The mixing thread's next `% RtPacketsCount` divides by zero → bugcheck.

The existing `RtPacketSize == 0` guard at function entry does not close this window: `RtPacketSize` and `RtPacketsCount` are always set/cleared together, but the guard is checked once at entry while the divisor is re-read every loop iteration ? a single point-in-time check cannot protect against a value that changes mid-loop on another thread.

## Changes

- `RtPacketObject.h`: add a private `WDFWAITLOCK m_rtPacketLock`, created in the constructor and parented to the device object (same pattern as existing locks in `StreamObject`).
- `RtPacketObject.cpp`:
  - `SetRtPackets` / `UnsetRtPackets`: acquire `m_rtPacketLock` around the read/write of `RtPackets` / `RtPacketsCount` / `RtPacketSize`.
  - `CopyFromRtPacketToOutputData` / `CopyToRtPacketFromInputData`: acquire `m_rtPacketLock` immediately after resolving the `RT_PACKET_INFO*` for the device, and release it at the single shared `_Exit` label each function already funnels every early-return path through, so the lock now covers the entire copy loop (all reads of `RtPacketsCount` / `RtPackets`).

This makes `Set/UnsetRtPackets` and the copy paths mutually exclusive, so `RtPacketsCount` can never be observed as zero mid-copy while a divide/modulo against it is in flight.

## Notes

- `m_rtPacketLock` is always the innermost lock acquired (never held while acquiring `StreamWaitLock` or `StreamEngineWaitLock`), so this does not introduce a new lock-ordering hazard with existing usages of those two locks.
- Both sides of the race run at `PASSIVE_LEVEL` (`PAGED_CODE_SEG`), so a `WDFWAITLOCK` is appropriate; no `DISPATCH_LEVEL` callers are involved.
- This fix addresses the specific divide-by-zero confirmed by this dump (`RtPacketObject.cpp:556`, dividing by `RtPacketsCount`). It is unrelated to a separate, not-yet-merged upstream fix ([`ef7a512d`](https://github.com/microsoft/low-latency-audio/commit/ef7a512d0877fe672fb963c31d4e767324416462)) for a different divide-by-zero in `TransferObject::CalculateEstimatedQPCPosition` (dividing by `m_transferredBytesInThisIrp`, tracked as issue #27) ? that one is out of scope for this PR.
- Kernel dump used for analysis (`081826-11625-01.dmp`) is attached for reference.

[081826-11625-01.dmp](https://github.com/user-attachments/files/31204945/081826-11625-01.dmp)
